### PR TITLE
feat: portfolio placeholder routes + ci: auto deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,58 @@
+name: Deploy To GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Add SPA fallback and nojekyll marker
+        run: |
+          cp dist/index.html dist/404.html
+          touch dist/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+.vite
 *.local
 
 # Editor directories and files

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 
 export default [
-  { ignores: ['dist'] },
+  { ignores: ['dist', '.vite'] },
   {
     files: ['**/*.{js,jsx}'],
     languageOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^7.14.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -1661,6 +1662,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2875,6 +2889,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2974,6 +3026,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.14.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,87 @@
-#root {
-  max-width: 1280px;
+.site-shell {
+  width: min(960px, 92vw);
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 2rem 0 3rem;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.site-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 2rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.site-kicker {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+.site-nav {
+  display: flex;
+  gap: 1rem;
 }
 
-.card {
-  padding: 2em;
+.site-nav a {
+  color: inherit;
+  text-decoration: none;
+  padding-bottom: 0.2rem;
+  border-bottom: 2px solid transparent;
+  font-weight: 600;
 }
 
-.read-the-docs {
-  color: #888;
+.site-nav a:hover {
+  color: var(--accent-strong);
+}
+
+.site-nav a.active {
+  font-weight: 700;
+  border-bottom-color: var(--accent-strong);
+}
+
+.page h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(2rem, 4.5vw, 3rem);
+}
+
+.page p {
+  margin-top: 0;
+  color: var(--muted);
+  max-width: 62ch;
+}
+
+.placeholder-card {
+  margin-top: 1.2rem;
+  padding: 1.25rem;
+  border-radius: 14px;
+  border: 1px dashed rgba(12, 54, 110, 0.3);
+  background: rgba(255, 255, 255, 0.65);
+  width: fit-content;
+}
+
+.project-grid {
+  margin-top: 1.4rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.project-card {
+  border-radius: 16px;
+  padding: 1rem;
+  background: linear-gradient(170deg, rgba(255, 255, 255, 0.95), rgba(225, 239, 255, 0.9));
+  border: 1px solid rgba(13, 87, 158, 0.2);
+}
+
+.project-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.project-card p {
+  margin: 0;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,37 +1,36 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { NavLink, Navigate, Route, Routes } from 'react-router-dom'
+import About from './pages/About.jsx'
+import CV from './pages/CV.jsx'
+import Projects from './pages/Projects.jsx'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1> My Personal Portfolio</h1>
-      <h2> Under construction</h2>
+    <div className="site-shell">
+      <header className="site-header">
+        <p className="site-kicker">Iasonas Papadopoulos</p>
+        <nav className="site-nav" aria-label="Main navigation">
+          <NavLink to="/about" className={({ isActive }) => (isActive ? 'active' : '')}>
+            About
+          </NavLink>
+          <NavLink to="/cv" className={({ isActive }) => (isActive ? 'active' : '')}>
+            CV
+          </NavLink>
+          <NavLink to="/" end className={({ isActive }) => (isActive ? 'active' : '')}>
+            Projects
+          </NavLink>
+        </nav>
+      </header>
 
-      <h1>Iasonas Papadopoulos</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+      <main>
+        <Routes>
+          <Route path="/" element={<Projects />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/cv" element={<CV />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </main>
+    </div>
   )
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,27 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Trebuchet MS', 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #13253c;
+  --accent: #0f6ab6;
+  --accent-strong: #0d4f8e;
+  --muted: #4a6280;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  background:
+    radial-gradient(circle at 15% 20%, rgba(38, 149, 214, 0.24), transparent 40%),
+    radial-gradient(circle at 80% 10%, rgba(86, 179, 155, 0.22), transparent 42%),
+    linear-gradient(145deg, #f8fbff, #eff5fc);
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,0 +1,13 @@
+function About() {
+  return (
+    <section className="page">
+      <h1>About</h1>
+      <p>
+        Iasonas Papadopoulos was born in Athens, Greece, and now lives in
+        Valladolid, Spain. LinkedIn profile: placeholder.
+      </p>
+    </section>
+  )
+}
+
+export default About

--- a/src/pages/CV.jsx
+++ b/src/pages/CV.jsx
@@ -1,0 +1,11 @@
+function CV() {
+  return (
+    <section className="page">
+      <h1>Curriculum Vitae</h1>
+      <p>Who am I?</p>
+      <div className="placeholder-card">CV coming soon.</div>
+    </section>
+  )
+}
+
+export default CV

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -1,0 +1,24 @@
+const projectItems = [
+  'ANC Demonstrator',
+  'DIY BT Airtags',
+  'DIY Portable Speaker',
+]
+
+function Projects() {
+  return (
+    <section className="page">
+      <h1>My Projects</h1>
+      <p>what I've built so far...</p>
+      <div className="project-grid">
+        {projectItems.map((title) => (
+          <article className="project-card" key={title}>
+            <h2>{title}</h2>
+            <p>Coming soon</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default Projects


### PR DESCRIPTION
## What this PR does
- Introduces basic portfolio skeleton to ship fast:
  - Home (`/`) -> Projects placeholder
  - About (`/about`)
  - CV (`/cv`)
- Adds top navigation: `About | CV | Projects`
- Adds GitHub Actions pipeline for automatic Pages deployment from `main`
- Workflow outline:
  - Trigger: push to `main` and manual dispatch
  - Build: checkout, setup Node 20, install deps, run build
  - Pages compatibility: generate `404.html` SPA fallback and `.nojekyll` marker
  - Deploy: upload `dist` artifact and publish with `deploy-pages` action

## Why
- Need fast live version at `iasonpap.github.io` with room to iterate later
- Avoid manual `gh-pages` branch deployment steps
- Ensure route refresh compatibility on GitHub Pages with `404.html` fallback

## Notes
- Content intentionally minimal (placeholder-first)
- No custom domain setup included in this PR
- This PR and code was vibecoded with GPT-5.3-Codex (Github Copilot). The results were verified locally.

## Validation
- `npm run lint` passes
- `npm run build` passes
- Routes verified locally:
  - `/`
  - `/about`
  - `/cv`

## Future work
- Replace CV placeholder with downloadable CV section
- Replace project placeholders with real project cards and project links
- Add final LinkedIn link and contact details
- Improve About page copy and visual polish
- Add simple tests and optional quality checks in CI before deploy